### PR TITLE
Implement backward compatible syntax simplification

### DIFF
--- a/back.html
+++ b/back.html
@@ -34,7 +34,7 @@
             try {
                 if (innerHTML && innerHTML !== textContent) {
                     // HTML formatting exists - use simple regex replacement with dark blue + bold
-                    var htmlProcessed = innerHTML.replace(/\[\[d\d+::([^\]]+)\]\]/g, '<strong style="color: #1565c0;">$1</strong>');
+                    var htmlProcessed = innerHTML.replace(/\[\[d\d*::([^\]]+)\]\]/g, '<strong style="color: #1565c0;">$1</strong>');
                     
                     if (htmlProcessed !== innerHTML) {
                         htmlProcessingResult = htmlProcessed;
@@ -47,7 +47,7 @@
             
             // Fallback to text processing
             try {
-                var textProcessed = textContent.replace(/\[\[d\d+::([^\]]+)\]\]/g, '$1');
+                var textProcessed = textContent.replace(/\[\[d\d*::([^\]]+)\]\]/g, '$1');
                 textProcessingResult = textProcessed;
                 textProcessingSuccess = true;
             } catch (error) {

--- a/documentation/CLAUDE.md
+++ b/documentation/CLAUDE.md
@@ -158,6 +158,31 @@ This is an interactive Anki flashcard template that creates drag-and-drop fill-i
 - **Status**: ❌ **Failed Implementation - Reverted**
 - **Next Steps**: Consider Approach 2 (Backward Compatibility) to support both syntaxes
 
+### ✅ Backward Compatible Syntax Simplification (Session 14)
+**Feature**: Implement `[[d::text]]` syntax with full backward compatibility
+- **Goal**: Support both `[[d1::text]]` (legacy) and `[[d::text]]` (new) syntax simultaneously
+- **Approach**: Version 2 - Smart regex with hybrid ID system
+- **Implementation**:
+  - **Add-on**: Generate `[[d::text]]` syntax (no numbering)
+  - **Smart regex**: Use `(\d*)` pattern to handle both numbered and unnumbered patterns
+  - **ID preservation**: Legacy `[[d1::text]]` keeps original ID `d1`, new `[[d::text]]` gets sequential IDs
+  - **Backward compatibility**: Existing cards continue working unchanged
+- **Technical Details**:
+  - **Front template**: `innerHTML.replace(/\[\[d(\d*)::([^\]]+)\]\]/g, function(match, num, text) { ... })`
+  - **ID generation**: 
+    - Legacy: `if (num && num.length > 0) { blankId = 'd' + num; }`
+    - New: `else { blankId = 'd' + nextAutoId; nextAutoId++; }`
+  - **Back template**: Updated regex to `/\[\[d\d*::([^\]]+)\]\]/g`
+- **Files Modified**:
+  - `drag_drop_addon/__init__.py`: Line 46 - Generate `[[d::text]]` syntax
+  - `front.html`: Lines 89-101, 132-144 - Smart regex processing
+  - `back.html`: Lines 37, 50 - Support both patterns
+- **Benefits**:
+  - **User Experience**: Simplified syntax for new content
+  - **Backward Compatibility**: Existing cards remain functional
+  - **Seamless Migration**: No user action required
+- **Status**: ✅ **Successfully Implemented**
+
 ### ✅ Formatting Preservation Implementation (Session 11)
 **Challenge**: Users reported that HTML formatting (bold, italic, colors) applied in the Question field was lost in both front and back templates.
 

--- a/drag_drop_addon/__init__.py
+++ b/drag_drop_addon/__init__.py
@@ -42,13 +42,8 @@ def create_drag_drop_blank_minimal(editor):
         
         field_content = editor.note.fields[current_field]
         
-        # Find next available counter (existing logic)
-        pattern = r'\[\[d(\d+)::[^\]]+\]\]'
-        matches = re.findall(pattern, field_content)
-        next_counter = max([int(match) for match in matches]) + 1 if matches else 1
-        
-        # Create the drag-drop syntax
-        wrapped_text = f"[[d{next_counter}::{selected_text}]]"
+        # Create the simplified drag-drop syntax (no numbering needed)
+        wrapped_text = f"[[d::{selected_text}]]"
         
         # Replace selected text using reliable insertText
         js_code = f"""
@@ -93,8 +88,8 @@ def create_drag_drop_blank_minimal(editor):
         def replacement_callback(result):
             if result and result.get('success'):
                 method = result.get('method', 'unknown')
-                tooltip(f"✅ Created d{next_counter}: \"{selected_text[:30]}{'...' if len(selected_text) > 30 else ''}\"", 2000)
-                print(f"Drag-Drop: Success - Created d{next_counter} using {method}")
+                tooltip(f"✅ Created blank: \"{selected_text[:30]}{'...' if len(selected_text) > 30 else ''}\"", 2000)
+                print(f"Drag-Drop: Success - Created blank using {method}")
             else:
                 error = result.get('error', 'Unknown error') if result else 'Replacement failed'
                 showInfo(f"Could not create drag-drop blank: {error}\n\nPlease try selecting the text again.")

--- a/front.html
+++ b/front.html
@@ -74,10 +74,28 @@ function parseQuestion() {
     // Test HTML processing
     try {
         if (innerHTML && innerHTML !== textContent) {
-            // HTML formatting exists - test simple regex replacement
+            // HTML formatting exists - use smart regex replacement
             var htmlAnswers = new Map();
-            var htmlProcessed = innerHTML.replace(/\[\[d(\d+)::([^\]]+)\]\]/g, function(match, num, text) {
-                var blankId = 'd' + num;
+            var nextAutoId = 1;
+            
+            // Find max existing number first
+            var maxNum = 0;
+            innerHTML.replace(/\[\[d(\d+)::([^\]]+)\]\]/g, function(match, num) {
+                maxNum = Math.max(maxNum, parseInt(num));
+            });
+            nextAutoId = maxNum + 1;
+            
+            // Process both patterns in one pass
+            var htmlProcessed = innerHTML.replace(/\[\[d(\d*)::([^\]]+)\]\]/g, function(match, num, text) {
+                var blankId;
+                if (num && num.length > 0) {
+                    // Legacy pattern: use original number
+                    blankId = 'd' + num;
+                } else {
+                    // New pattern: generate sequential ID
+                    blankId = 'd' + nextAutoId;
+                    nextAutoId++;
+                }
                 htmlAnswers.set(blankId, text);
                 return '<span class="answer-input" data-blank-id="' + blankId + '"></span>';
             });
@@ -101,8 +119,26 @@ function parseQuestion() {
     // Test text processing (fallback)
     try {
         var textAnswers = new Map();
-        var textProcessed = questionField.replace(/\[\[d(\d+)::([^\]]+)\]\]/g, function(match, num, text) {
-            var blankId = 'd' + num;
+        var nextAutoId = 1;
+        
+        // Find max existing number first
+        var maxNum = 0;
+        questionField.replace(/\[\[d(\d+)::([^\]]+)\]\]/g, function(match, num) {
+            maxNum = Math.max(maxNum, parseInt(num));
+        });
+        nextAutoId = maxNum + 1;
+        
+        // Process both patterns in one pass
+        var textProcessed = questionField.replace(/\[\[d(\d*)::([^\]]+)\]\]/g, function(match, num, text) {
+            var blankId;
+            if (num && num.length > 0) {
+                // Legacy pattern: use original number
+                blankId = 'd' + num;
+            } else {
+                // New pattern: generate sequential ID
+                blankId = 'd' + nextAutoId;
+                nextAutoId++;
+            }
             textAnswers.set(blankId, text);
             return '<span class="answer-input" data-blank-id="' + blankId + '"></span>';
         });
@@ -119,7 +155,7 @@ function parseQuestion() {
                 });
             }
         } else {
-            textProcessingResult = questionField + '<br><br><em style="color: #666;">No drag-drop blanks found. Use the add-on to create [[d1::text]] syntax.</em>';
+            textProcessingResult = questionField + '<br><br><em style="color: #666;">No drag-drop blanks found. Use the add-on to create [[d::text]] syntax.</em>';
             textProcessingSuccess = true;
             processingMethod = 'text';
         }
@@ -154,9 +190,9 @@ function createDraggableItems() {
     var textContent = questionData.textContent;
     var innerHTML = questionData.innerHTML;
     
-    // Extract items from [[dN::text]] syntax
+    // Extract items from [[dN::text]] and [[d::text]] syntax
     var items = [];
-    var regex = /\[\[d\d+::([^\]]+)\]\]/g;
+    var regex = /\[\[d\d*::([^\]]+)\]\]/g;
     var match;
     
     // Try HTML processing first for formatted items
@@ -165,7 +201,7 @@ function createDraggableItems() {
         try {
             // Extract items from HTML content
             var htmlItems = [];
-            var htmlRegex = /\[\[d\d+::([^\]]+)\]\]/g;
+            var htmlRegex = /\[\[d\d*::([^\]]+)\]\]/g;
             var htmlMatch;
             
             while ((htmlMatch = htmlRegex.exec(innerHTML)) !== null) {
@@ -202,7 +238,7 @@ function createDraggableItems() {
     
     // If no items found, show helpful message
     if (items.length === 0) {
-        itemCollection.innerHTML = '<p style="color: #666; font-style: italic;">No draggable items found. Use the add-on to create [[d1::text]] syntax.</p>';
+        itemCollection.innerHTML = '<p style="color: #666; font-style: italic;">No draggable items found. Use the add-on to create [[d::text]] syntax.</p>';
         return;
     }
     


### PR DESCRIPTION
## Summary
- Add support for simplified `[[d::text]]` syntax alongside legacy `[[d1::text]]`
- New content uses cleaner format while preserving existing cards
- Smart regex handles both patterns with proper ID generation
- Full backward compatibility - no user migration required

## Technical Implementation
- **Add-on**: Generate `[[d::text]]` syntax instead of `[[d1::text]]`
- **Front template**: Smart regex with hybrid ID system using `(\d*)` pattern
- **Back template**: Support both syntax patterns with updated regex
- **ID preservation**: Legacy cards maintain original numbering, new cards get sequential IDs

## Benefits
- **User Experience**: Simplified syntax for new content creation
- **Backward Compatibility**: Existing cards remain fully functional
- **Seamless Migration**: No user action required for existing content
- **Conflict Prevention**: Sequential ID generation prevents numbering conflicts

## Test Plan
- [x] Test legacy `[[d1::text]]` cards continue working
- [x] Test new `[[d::text]]` cards generate properly
- [x] Test mixed content with both syntaxes
- [x] Verify drag-and-drop functionality preserved
- [x] Confirm answer display works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)